### PR TITLE
Background keep-alive + session persistence (1.6.2-pre.1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ android {
     defaultConfig {
         minSdkVersion project.properties.minSdkVersion.toInteger()
         targetSdkVersion project.properties.targetSdkVersion.toInteger()
-        versionCode 26
-        versionName "1.6.2-pre.1"
+        versionCode 27
+        versionName "1.6.2-pre.2"
 
         if (appVersionName) versionName = appVersionName
         validateVersionName(versionName)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ android {
     defaultConfig {
         minSdkVersion project.properties.minSdkVersion.toInteger()
         targetSdkVersion project.properties.targetSdkVersion.toInteger()
-        versionCode 25
-        versionName "1.6.1"
+        versionCode 26
+        versionName "1.6.2-pre.1"
 
         if (appVersionName) versionName = appVersionName
         validateVersionName(versionName)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ android {
     defaultConfig {
         minSdkVersion project.properties.minSdkVersion.toInteger()
         targetSdkVersion project.properties.targetSdkVersion.toInteger()
-        versionCode 27
-        versionName "1.6.2-pre.2"
+        versionCode 28
+        versionName "1.6.2"
 
         if (appVersionName) versionName = appVersionName
         validateVersionName(versionName)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.READ_LOGS" />
@@ -222,9 +223,19 @@
             android:exported="false" />
 
 
+        <!-- specialUse (API 34) gives the keep-alive foreground service a real
+             foregroundServiceType so the host process is not treated as "empty" and
+             cheaply reclaimable while a fullscreen game is in the foreground. Unlike
+             dataSync it carries no daily-runtime cap, which fits a long-lived terminal.
+             The value is ignored on pre-34 devices; the notification path is unchanged. -->
         <service
             android:name=".app.TermuxService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="terminal-session-keepalive" />
+        </service>
 
         <service
             android:name=".app.RunCommandService"

--- a/app/src/main/java/com/newtermux/features/NewTermuxSettings.java
+++ b/app/src/main/java/com/newtermux/features/NewTermuxSettings.java
@@ -25,6 +25,9 @@ public class NewTermuxSettings {
     public static final String KEY_TEXT_EXPANSION_ENABLED    = "text_expansion_enabled";
     public static final String KEY_EXTRA_KEYS_VISIBLE        = "extra_keys_visible";
     public static final String KEY_EXTRA_KEYS_IN_DRAWER      = "extra_keys_in_drawer";
+    public static final String KEY_KEEP_ALIVE_BACKGROUND     = "keep_alive_background";
+    // Internal one-time gate: set once we have shown the battery-optimization nudge.
+    public static final String KEY_BATTERY_OPT_PROMPTED      = "battery_opt_prompted";
 
     private static SharedPreferences prefs(Context ctx) {
         return ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
@@ -88,6 +91,19 @@ public class NewTermuxSettings {
     public static boolean isExtraKeysInDrawer(Context ctx) {
         return prefs(ctx).getBoolean(KEY_EXTRA_KEYS_IN_DRAWER, false);
     }
+    /** Whether the process should hold a foreground wake lock while sessions are alive so it
+     *  survives being backgrounded by a fullscreen game. Defaults ON. */
+    public static boolean isKeepAliveInBackground(Context ctx) {
+        return prefs(ctx).getBoolean(KEY_KEEP_ALIVE_BACKGROUND, true);
+    }
+
+    // One-time battery-optimization nudge gate.
+    public static boolean wasBatteryOptPrompted(Context ctx) {
+        return prefs(ctx).getBoolean(KEY_BATTERY_OPT_PROMPTED, false);
+    }
+    public static void setBatteryOptPrompted(Context ctx, boolean v) {
+        prefs(ctx).edit().putBoolean(KEY_BATTERY_OPT_PROMPTED, v).apply();
+    }
 
     // Pending command — written by Settings, consumed and cleared by TermuxActivity.onResume()
     public static String getPendingCommand(Context ctx) {
@@ -126,6 +142,7 @@ public class NewTermuxSettings {
             case KEY_TEXT_EXPANSION_ENABLED:       return isTextExpansionEnabled(ctx);
             case KEY_EXTRA_KEYS_VISIBLE:           return isExtraKeysVisible(ctx);
             case KEY_EXTRA_KEYS_IN_DRAWER:         return isExtraKeysInDrawer(ctx);
+            case KEY_KEEP_ALIVE_BACKGROUND:        return isKeepAliveInBackground(ctx);
             default:                               return prefs(ctx).getBoolean(key, false);
         }
     }

--- a/app/src/main/java/com/termux/app/SessionStatePersister.java
+++ b/app/src/main/java/com/termux/app/SessionStatePersister.java
@@ -1,0 +1,107 @@
+package com.termux.app;
+
+import android.content.Context;
+
+import com.termux.shared.shell.command.ExecutionCommand;
+import com.termux.shared.termux.TermuxConstants;
+import com.termux.shared.termux.shell.command.runner.terminal.TermuxSession;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Persists the live session list (name + cwd + failsafe flag) to disk so that
+ * if the com.termux process is torn down in the background (e.g. while a
+ * fullscreen game is in the foreground), the next launch can recreate the same
+ * set of tabs.
+ *
+ * IMPORTANT — this restores the VIEW, not the compute:
+ *   What IS persisted (per session): shellName, workingDirectory, isFailsafe.
+ *   What is NOT persisted: the PTY, scrollback, and any in-flight child
+ *   processes. Those die with the PID and cannot be revived. A `claude` CLI
+ *   that was running is gone — reopen the restored tab and `claude --continue`
+ *   to resume conversation state from ~/.claude/.
+ *
+ * All I/O here is best-effort: a persistence failure must never crash the app.
+ */
+public final class SessionStatePersister {
+
+    private static final String DIR_NAME  = ".termux";
+    private static final String FILE_NAME = "session_state.json";
+
+    public static final class Snapshot {
+        public String  name;
+        public String  cwd;
+        public boolean failsafe;
+    }
+
+    private static File stateFile() {
+        File dir = new File(TermuxConstants.TERMUX_FILES_DIR_PATH, DIR_NAME);
+        if (!dir.exists()) dir.mkdirs();
+        return new File(dir, FILE_NAME);
+    }
+
+    /** Best-effort snapshot of the current session list. Never throws. Atomic rename on success. */
+    public static void save(Context ctx, List<TermuxSession> sessions) {
+        if (sessions == null) return;
+        try {
+            JSONArray arr = new JSONArray();
+            for (TermuxSession s : sessions) {
+                if (s == null) continue;
+                ExecutionCommand ec = s.getExecutionCommand();
+                if (ec == null) continue;
+                JSONObject o = new JSONObject();
+                o.put("name",     ec.shellName        == null ? "" : ec.shellName);
+                o.put("cwd",      ec.workingDirectory == null ? "" : ec.workingDirectory);
+                o.put("failsafe", ec.isFailsafe);
+                arr.put(o);
+            }
+            File f   = stateFile();
+            File tmp = new File(f.getParentFile(), FILE_NAME + ".tmp");
+            try (FileWriter w = new FileWriter(tmp)) {
+                w.write(arr.toString());
+            }
+            // POSIX rename = atomic on same filesystem.
+            if (!tmp.renameTo(f)) {
+                tmp.delete();
+            }
+        } catch (Exception ignored) { }
+    }
+
+    /** Best-effort load of the last snapshot. Never throws; returns an empty list on any failure. */
+    public static List<Snapshot> load() {
+        List<Snapshot> out = new ArrayList<>();
+        File f = stateFile();
+        if (!f.exists()) return out;
+        try {
+            String json = new String(Files.readAllBytes(Paths.get(f.getAbsolutePath())));
+            JSONArray arr = new JSONArray(json);
+            for (int i = 0; i < arr.length(); i++) {
+                JSONObject o = arr.getJSONObject(i);
+                Snapshot s = new Snapshot();
+                s.name     = o.optString("name", "");
+                s.cwd      = o.optString("cwd",  "");
+                s.failsafe = o.optBoolean("failsafe", false);
+                out.add(s);
+            }
+        } catch (Exception ignored) { }
+        return out;
+    }
+
+    /** Drop the snapshot so a subsequent launch starts fresh (used on explicit stop). */
+    public static void clear() {
+        try {
+            File f = stateFile();
+            if (f.exists()) f.delete();
+        } catch (Exception ignored) { }
+    }
+
+    private SessionStatePersister() { }
+}

--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -385,8 +385,9 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
 
         registerTermuxActivityBroadcastReceiver();
 
-        if (mTermuxService != null)
-            mTermuxService.releaseWakeLockAuto();
+        // NOTE: the keep-alive wake lock is intentionally NOT released here anymore. It is now tied
+        // to the session lifecycle in TermuxService (held while any session is alive), not to the
+        // Activity lifecycle — releasing it on every foreground transition is what made it flap.
     }
 
     @Override
@@ -427,6 +428,11 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         if (mTermuxTerminalSessionActivityClient != null)
             mTermuxTerminalSessionActivityClient.checkForFontAndColors();
 
+        // One-time nudge to allowlist NewTermux from battery optimization / Doze, so the keep-alive
+        // foreground service actually survives backgrounding. Gated: only shows if keep-alive is on,
+        // we are not already exempt, and we have not asked before.
+        maybePromptBatteryOptimization();
+
         // Run any command injected by Settings (e.g. "pkg install zsh\n")
         String pendingCmd = com.newtermux.features.NewTermuxSettings.getPendingCommand(this);
         if (pendingCmd != null) {
@@ -437,6 +443,34 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
                 session.write(bytes, 0, bytes.length);
             }
         }
+    }
+
+    /**
+     * Show a one-time dialog asking the user to allowlist NewTermux from battery optimization /
+     * Doze. Without the exemption, Android can still tear the process down in the background even
+     * with a foreground service + wake lock. Gated so it is unobtrusive: only when keep-alive is
+     * enabled, we are not already exempt, and we have not prompted before.
+     */
+    private void maybePromptBatteryOptimization() {
+        if (!com.newtermux.features.NewTermuxSettings.isKeepAliveInBackground(this)) return;
+        if (com.newtermux.features.NewTermuxSettings.wasBatteryOptPrompted(this)) return;
+        if (PermissionUtils.checkIfBatteryOptimizationsDisabled(this)) return;
+
+        // Mark as prompted up front so this only ever appears once, regardless of the user's choice.
+        com.newtermux.features.NewTermuxSettings.setBatteryOptPrompted(this, true);
+
+        new AlertDialog.Builder(this)
+            .setTitle(R.string.battery_opt_prompt_title)
+            .setMessage(R.string.battery_opt_prompt_message)
+            .setPositiveButton(R.string.battery_opt_prompt_allow, (d, w) -> {
+                try {
+                    PermissionUtils.requestDisableBatteryOptimizations(this);
+                } catch (Exception e) {
+                    Logger.logError(LOG_TAG, "Failed to request battery optimization exemption: " + e);
+                }
+            })
+            .setNegativeButton(R.string.battery_opt_prompt_later, null)
+            .show();
     }
 
     private void applyAccentColor() {
@@ -502,8 +536,11 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
         unregisterTermuxActivityBroadcastReceiver();
         getDrawer().closeDrawers();
 
+        // Snapshot the current tab list to disk as we go to background, so that if the process is
+        // torn down while a game is in the foreground, the next launch can rehydrate the tabs. The
+        // keep-alive wake lock is already held continuously by the service (session-driven).
         if (mTermuxService != null)
-            mTermuxService.acquireWakeLockAuto();
+            SessionStatePersister.save(this, mTermuxService.getTermuxSessions());
     }
 
     @Override

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -7,6 +7,7 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.content.res.Resources;
 import android.net.wifi.WifiManager;
 import android.os.Binder;
@@ -213,7 +214,17 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
     /** Make service run in foreground mode. */
     private void runStartForeground() {
         setupNotificationChannel();
-        startForeground(TermuxConstants.TERMUX_APP_NOTIFICATION_ID, buildNotification());
+        Notification notification = buildNotification();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // On Android 14+ a foreground service with no foregroundServiceType is treated as
+            // "empty" and is cheaply reclaimable (observed kill: reason=3 LOW_MEMORY, types=0).
+            // Declaring the specialUse type (matching the manifest) keeps the host process alive
+            // while a fullscreen game is foregrounded. specialUse has no daily-runtime cap.
+            startForeground(TermuxConstants.TERMUX_APP_NOTIFICATION_ID, notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE);
+        } else {
+            startForeground(TermuxConstants.TERMUX_APP_NOTIFICATION_ID, notification);
+        }
     }
 
     /** Make service leave foreground mode. */

--- a/app/src/main/java/com/termux/app/TermuxService.java
+++ b/app/src/main/java/com/termux/app/TermuxService.java
@@ -31,6 +31,7 @@ import com.termux.shared.shell.command.runner.app.AppShell;
 import com.termux.shared.termux.settings.properties.TermuxAppSharedProperties;
 import com.termux.shared.termux.shell.command.environment.TermuxShellEnvironment;
 import com.termux.shared.termux.shell.TermuxShellUtils;
+import com.newtermux.features.NewTermuxSettings;
 import com.termux.shared.termux.TermuxConstants;
 import com.termux.shared.termux.TermuxConstants.TERMUX_APP.TERMUX_ACTIVITY;
 import com.termux.shared.termux.TermuxConstants.TERMUX_APP.TERMUX_SERVICE;
@@ -121,6 +122,14 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         mShellManager = TermuxShellManager.getShellManager();
 
         runStartForeground();
+
+        // If the process was just resurrected by AM (sticky service restart) after being torn down
+        // in the background, mShellManager is empty. Rehydrate the tab list from disk so the user
+        // gets their sessions (name + cwd) back instead of a single blank shell.
+        restoreSessionsIfNeeded();
+
+        // Hold the keep-alive wake lock continuously while any session is alive.
+        updateWakeLockForKeepAlive();
 
         SystemEventReceiver.registerPackageUpdateEvents(this);
     }
@@ -222,6 +231,9 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
     /** Process action to stop service. */
     private void actionStopService() {
         mWantsToStop = true;
+        // User explicitly stopped the service — drop the persisted tab snapshot so the next launch
+        // starts fresh instead of rehydrating the sessions we are about to kill.
+        SessionStatePersister.clear();
         killAllTermuxExecutionCommands();
         requestStopService();
     }
@@ -320,9 +332,10 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         mWifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, TermuxConstants.TERMUX_APP_NAME.toLowerCase());
         mWifiLock.acquire();
 
-        if (!PermissionUtils.checkIfBatteryOptimizationsDisabled(this)) {
-            PermissionUtils.requestDisableBatteryOptimizations(this);
-        }
+        // NOTE: the battery-optimization exemption is requested from TermuxActivity (a proper
+        // Activity context, one-time) rather than here — a service-context request needs
+        // FLAG_ACTIVITY_NEW_TASK and is silently dropped by background-start restrictions on
+        // modern Android, and firing it on every acquire was spammy.
 
         updateNotification();
 
@@ -359,18 +372,63 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
         return mWakeLock != null;
     }
 
-    /** Acquire wake lock automatically when activity goes to background. No-op if already held. */
-    public void acquireWakeLockAuto() {
-        if (mWakeLock != null) return;
-        mAutoWakeLock = true;
-        actionAcquireWakeLock();
+    /**
+     * Keep the partial wake lock + foreground service held CONTINUOUSLY while any terminal
+     * session is alive and the "Keep alive in background" setting is on, so the process survives
+     * being backgrounded by a fullscreen game. Acquired when the first session starts, released
+     * only when the last session ends (or the user explicitly stops the service).
+     *
+     * This replaces the previous behavior where the lock was tied to the Activity's
+     * onStart()/onStop() and so flapped (acquire/release) on every lifecycle transition — a game
+     * launch or PiP toggle would release it right when it was needed most.
+     *
+     * A user-held lock (toggled from the notification action) has mAutoWakeLock == false and is
+     * left untouched here.
+     */
+    public synchronized void updateWakeLockForKeepAlive() {
+        boolean keepAlive = NewTermuxSettings.isKeepAliveInBackground(this)
+            && !mShellManager.mTermuxSessions.isEmpty()
+            && !mWantsToStop;
+
+        if (keepAlive) {
+            if (mWakeLock == null) {
+                mAutoWakeLock = true;
+                actionAcquireWakeLock();
+            }
+        } else if (mAutoWakeLock) {
+            mAutoWakeLock = false;
+            actionReleaseWakeLock(true);
+        }
     }
 
-    /** Release wake lock if it was auto-acquired; leaves user-acquired wake locks alone. */
-    public void releaseWakeLockAuto() {
-        if (!mAutoWakeLock) return;
-        mAutoWakeLock = false;
-        actionReleaseWakeLock(true);
+    /**
+     * Rehydrate the tab list from disk if the process was resurrected with no live sessions.
+     * Restores the VIEW only — session name + working directory + failsafe flag. The PTY,
+     * scrollback, and any child process (e.g. a running claude CLI) died with the old PID and
+     * cannot be revived; the user resumes those with `claude --continue` etc.
+     */
+    private void restoreSessionsIfNeeded() {
+        if (mShellManager == null || !mShellManager.mTermuxSessions.isEmpty()) return;
+        List<SessionStatePersister.Snapshot> snaps = SessionStatePersister.load();
+        if (snaps.isEmpty()) return;
+
+        Logger.logInfo(LOG_TAG, "Restoring " + snaps.size() + " session(s) from persisted state");
+        for (SessionStatePersister.Snapshot s : snaps) {
+            try {
+                createTermuxSession(
+                    /* executablePath   */ null,   // default login shell
+                    /* arguments        */ null,
+                    /* stdin            */ null,
+                    /* workingDirectory */ (s.cwd == null || s.cwd.isEmpty())
+                                            ? TermuxConstants.TERMUX_HOME_DIR_PATH
+                                            : s.cwd,
+                    /* isFailSafe       */ s.failsafe,
+                    /* sessionName      */ s.name
+                );
+            } catch (Throwable t) {
+                Logger.logError(LOG_TAG, "Restore failed for session '" + s.name + "': " + t);
+            }
+        }
     }
 
     /** Process {@link TERMUX_SERVICE#ACTION_SERVICE_EXECUTE} intent to execute a shell command in
@@ -626,6 +684,11 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
 
         mShellManager.mTermuxSessions.add(newTermuxSession);
 
+        // Keep the persisted tab snapshot current and (re)acquire the keep-alive wake lock now that
+        // at least one session exists.
+        SessionStatePersister.save(this, new ArrayList<>(mShellManager.mTermuxSessions));
+        updateWakeLockForKeepAlive();
+
         // Remove the execution command from the pending plugin execution commands list since it has
         // now been processed
         if (executionCommand.isPluginExecutionCommand)
@@ -667,6 +730,11 @@ public final class TermuxService extends Service implements AppShell.AppShellCli
                 TermuxPluginUtils.processPluginExecutionCommandResult(this, LOG_TAG, executionCommand);
 
             mShellManager.mTermuxSessions.remove(termuxSession);
+
+            // Snapshot the reduced list so an exited session is NOT rehydrated next launch, and
+            // release the keep-alive wake lock once the last session is gone.
+            SessionStatePersister.save(this, new ArrayList<>(mShellManager.mTermuxSessions));
+            updateWakeLockForKeepAlive();
 
             // Notify {@link TermuxSessionsListViewController} that sessions list has been updated if
             // activity in is foreground

--- a/app/src/main/java/com/termux/app/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/termux/app/activities/SettingsActivity.kt
@@ -58,6 +58,7 @@ import com.newtermux.compose.outlinedMenuCard
 import com.newtermux.features.NewTermuxSettings
 import com.newtermux.features.TextExpansionStore
 import com.termux.app.TermuxActivity
+import com.termux.shared.android.PermissionUtils
 import com.termux.app.TermuxInstaller
 import com.termux.app.models.UserAction
 import com.termux.shared.android.AndroidUtils
@@ -197,6 +198,30 @@ private fun NtSwitch(context: Context, key: String, title: String, summary: Stri
     }
 }
 
+/**
+ * "Keep alive in background" toggle. Backed by NewTermuxSettings, and when enabled it also asks
+ * the user to allowlist the app from battery optimization (if not already exempt) since the wake
+ * lock alone can still lose to Doze.
+ */
+@Composable
+private fun KeepAliveSwitch(activity: Activity) {
+    val context = LocalContext.current
+    var checked by remember { mutableStateOf(NewTermuxSettings.isKeepAliveInBackground(context)) }
+    SwitchRow(
+        title = "Keep alive in background",
+        summary = "Hold a foreground wake lock while sessions run so the app survives when you launch a game. Turn off to save battery.",
+        checked = checked,
+    ) {
+        checked = it
+        NewTermuxSettings.set(context, NewTermuxSettings.KEY_KEEP_ALIVE_BACKGROUND, it)
+        if (it && !PermissionUtils.checkIfBatteryOptimizationsDisabled(context)) {
+            // Mark prompted so the first-run nudge won't also fire, then request the exemption.
+            NewTermuxSettings.setBatteryOptPrompted(context, true)
+            runCatching { PermissionUtils.requestDisableBatteryOptimizations(activity) }
+        }
+    }
+}
+
 @Composable
 private fun LogLevelRow(context: Context, current: Int, onSelect: (Int) -> Unit) {
     val values = remember { Logger.getLogLevelsArray().map { it.toString() } }
@@ -310,6 +335,9 @@ private fun FeaturesScreen(activity: Activity, onBack: () -> Unit) {
             NtSwitch(context, NewTermuxSettings.KEY_SHOW_DRAWER_EXPORT_SCRIPT, "Export Screen & Make Script", "Show Export Screen and Make Script buttons in the drawer")
             NtSwitch(context, NewTermuxSettings.KEY_SHOW_DRAWER_PKG_UPDATE, "Pkg Update Button", "Show a button that runs pkg update && pkg upgrade -y")
             NtSwitch(context, NewTermuxSettings.KEY_SHOW_DRAWER_CMD_BUTTONS, "Drawer Command Buttons", "Show customisable command shortcut buttons")
+
+            CategoryHeader("Background")
+            KeepAliveSwitch(activity)
 
             CategoryHeader("Permissions")
             NavRow("Grant Storage Permission", "Allow access to /sdcard and set up ~/storage symlinks") {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,4 +235,12 @@
     <!-- Donate Preference -->
     <string name="donate_preference_title">Donate</string>
 
+    <!-- Keep alive in background / battery optimization -->
+    <string name="keep_alive_background_title">Keep alive in background</string>
+    <string name="keep_alive_background_summary">Hold a foreground wake lock while sessions are running so the app survives when you launch a game. Turn off to save battery.</string>
+    <string name="battery_opt_prompt_title">Keep NewTermux running</string>
+    <string name="battery_opt_prompt_message">To keep your terminal sessions alive while a game is in the foreground, allow NewTermux to ignore battery optimizations. Without this, Android may still shut the app down in the background.</string>
+    <string name="battery_opt_prompt_allow">Allow</string>
+    <string name="battery_opt_prompt_later">Not now</string>
+
 </resources>


### PR DESCRIPTION
## Summary
Hardens NewTermux against being backgrounded when a fullscreen game launches, and adds a safety net that brings terminal tabs back if the process is torn down anyway.

**This is an untested test build — do not merge.** It is CI-gated only; the behavior is device-UNPROVEN.

## Changes
1. **Continuous foreground keep-alive.** The partial wake lock is now tied to the session lifecycle (held while any terminal session is alive) instead of the Activity's `onStart`/`onStop`. The old activity-lifecycle coupling made the lock flap (acquire/release) on every lifecycle transition — a game launch or PiP toggle would release it exactly when it was needed. Acquired on first session, released on last session or explicit stop. Gated by a new **Keep alive in background** setting (default ON).
2. **Battery-optimization / Doze exemption.** A one-time, gated prompt using `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, shown from a proper Activity context (the previous service-context request was dropped by background-start restrictions and fired on every acquire). Only appears if not already exempt and not asked before; also surfaced when enabling the keep-alive setting.
3. **Session persistence (safety net).** `SessionStatePersister` writes the open tab list (name + working directory + failsafe flag) to `~/.termux/session_state.json` and rehydrates it on a sticky service restart. This restores the **view** (tabs + cwd) only — **not** live PIDs. A killed `claude`/`ssh` process cannot be revived; resume with `claude --continue`.

## Versioning
- versionCode 25 → 26
- versionName 1.6.1 → 1.6.2-pre.1 (pre-release test build)

## Testing
CI (`debug_build.yml`) only. Not yet verified on device.
